### PR TITLE
Error correction in the _on_off method

### DIFF
--- a/custom_components/binary_sensor/NooLite.py
+++ b/custom_components/binary_sensor/NooLite.py
@@ -113,7 +113,8 @@ class NooLiteBinarySensor(BinarySensorDevice):
         self._timer.start()
 
     def _on_off(self):
-        self._timer.cancel()
+        if self._timer is not None:
+            self._timer.cancel()
         self._timer = None
         self._switch_off()
         self.schedule_update_ha_state()


### PR DESCRIPTION
If there is no object reference in self._timer, an exception occurs when you call self._timer.cancel ().
Therefore, the call needs to be wrapped by verification.